### PR TITLE
[fix]-Make-up-one-film-card-template---Add-CSS-styles

### DIFF
--- a/src/sass/layout/_film-card.scss
+++ b/src/sass/layout/_film-card.scss
@@ -33,9 +33,18 @@
 .cards-list__info {
   display: flex;
   flex-direction: column;
+  width: 280px;
   margin-top: 10px;
   font-family: Roboto;
   font-weight: 500;
+
+  @media screen and (min-width: 768px) {
+    width: 294px;
+  }
+
+  @media screen and (min-width: 1024px) {
+    width: 274px;
+  }
 }
 .cards-list__info-name {
   font-size: 12px;

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -16,6 +16,7 @@
 @import './layout/footer';
 @import './layout/card-modal';
 @import './layout/team-modal';
+@import './layout/film-card';
 
 /* PAGES */
 @import './pages/main-page';


### PR DESCRIPTION
1. Fix styles in file "_film-card.scss":
    Add media rules for heading h1 for different breakpoints to eliminate unnecessary spacing between cards;

2. Submit the path to the "_film-card.scss" file in the "main.scss" file.