### PR TITLE
[fix] Body scrolls when modal is open

### DIFF
--- a/src/js/modules/components/render-one-card-modal.js
+++ b/src/js/modules/components/render-one-card-modal.js
@@ -21,11 +21,19 @@ class RenderModal {
   async onModalOpenClick(evt) {
     evt.preventDefault();
 
+    document.body.style.overflow = 'hidden';
+    document.body.style.marginRight = '17px';
+
     this.instance = basicLightbox.create(`<div></div>`, {
       onShow: instance => {
         instance.element().querySelector('.close').onclick = instance.close;
       },
+      onClose: () => {
+        document.body.style.overflow = '';
+        document.body.style.marginRight = '';
+      },
     });
+
     const cardsList = evt.target.parentNode;
     this.cardsListId = cardsList.id;
     const iscardsList = cardsList.classList.contains('cards-list__item');


### PR DESCRIPTION
*JS*
- Add body.style.overflow = 'hidden' for remove scroll from body when modal is open and remove overflow
 when it is close in render-one-card-modal.js
- Add body.style.marginRight = '17px'  when modal is open and remove marginRight  when it is close for prevent jumping in render-one-card-modal.js