### PR TITLE
[refactor] Save whole movie object to local storage instead of id

### DIFF
--- a/src/js/modules/components/library-storage.js
+++ b/src/js/modules/components/library-storage.js
@@ -16,14 +16,17 @@ export class LibraryStorage {
     }
     return JSON.parse(storageItem);
   }
-  addToStorage(id) {
+  addToStorage(movie) {
     const storage = this.getStorageList();
-    storage.unshift(id);
+    if (storage.some(x => x.id == movie.id)) {
+      return;
+    }
+    storage.unshift(movie);
     localStorage.setItem(this.key, JSON.stringify(storage));
   }
-  removeFromStorage(id) {
+  removeFromStorageById(id) {
     const storage = this.getStorageList();
-    const indexOfId = storage.indexOf(id);
+    const indexOfId = storage.findIndex(x => x.id == id);
     if (indexOfId === -1) return;
     storage.splice(indexOfId, 1);
     localStorage.setItem(this.key, JSON.stringify(storage));
@@ -31,8 +34,8 @@ export class LibraryStorage {
 
   hasId(id) {
     const storage = this.getStorageList();
-    return storage.includes(id);
+    return storage.some(x => x.id == id);
   }
 }
-export const watchedStorage = new LibraryStorage('watched');
-export const queueStorage = new LibraryStorage('queue');
+export const watchedStorage = new LibraryStorage('watchedMovies');
+export const queueStorage = new LibraryStorage('queueMovies');

--- a/src/js/modules/components/movie-service.js
+++ b/src/js/modules/components/movie-service.js
@@ -133,37 +133,31 @@ class MovieService {
   }
 
   async renderMarkupAtLibraryPage(tab) {
-    let ids =
+    let movies =
       tab === 'watched'
         ? watchedStorage.getStorageList()
         : queueStorage.getStorageList();
-    if (ids.length <= this.options.itemsPerPage) {
+    if (movies.length <= this.options.itemsPerPage) {
       this.container.classList.add('visually-hidden');
     } else if (this.container.classList.contains('visually-hidden')) {
       this.container.classList.remove('visually-hidden');
     }
     const pagin = new Pagination(this.container, {
       ...this.options,
-      totalItems: ids.length,
+      totalItems: movies.length,
     });
     pagin.on('afterMove', async event => {
       const page = event.page;
-      await this.renderPageMarkupAtLibraryPage(ids, page);
+      await this.renderPageMarkupAtLibraryPage(movies, page);
     });
-    await this.renderPageMarkupAtLibraryPage(ids, 1);
+    await this.renderPageMarkupAtLibraryPage(movies, 1);
   }
 
-  async renderPageMarkupAtLibraryPage(ids, page) {
+  async renderPageMarkupAtLibraryPage(movies, page) {
     const from = (page - 1) * this.options.itemsPerPage;
     const to = page * this.options.itemsPerPage;
-    const pageIds = ids.slice(from, to);
-    const movies = await Promise.all(
-      pageIds.map(id => this.movies.getMovieById(id)),
-    );
-    for (let movie of movies) {
-      movie.genre_ids = movie.genres.map(x => x.id);
-    }
-    this.renderMovies(movies, 'library');
+    const pageMovies = movies.slice(from, to);
+    this.renderMovies(pageMovies, 'library');
   }
 
   async renderMovies(movies, page, libraryTab) {

--- a/src/js/modules/components/render-one-card-modal.js
+++ b/src/js/modules/components/render-one-card-modal.js
@@ -47,13 +47,13 @@ class RenderModal {
       return;
     }
 
-    const data = await this.themoviedbApi.getMovieById(this.cardsListId);
-    const genre = data.genres.map(id => id.name);
+    this.currentMovie = await this.themoviedbApi.getMovieById(this.cardsListId);
+    const genre = this.currentMovie.genres.map(id => id.name);
     const genreIds = Object.values(genre).join(', ');
     console.log(this.movieAdded);
 
     this.instance.element().innerHTML = modalMarkup(
-      data,
+      this.currentMovie,
       genreIds,
       this.cardsListId,
       this.movieAddedtoWatched,
@@ -84,11 +84,14 @@ class RenderModal {
   onBtnWatchedClick() {
     this.btnWatched.classList.add('modal__btn-watched--active');
     if (this.movieAddedtoWatched !== true) {
-      watchedStorage.addToStorage(this.cardsListId);
+      watchedStorage.addToStorage({
+        ...this.currentMovie,
+        genre_ids: this.currentMovie.genres.map(x => x.id),
+      });
       this.btnWatched.textContent = 'Remove from watched';
       this.btnWatched.blur();
     } else {
-      watchedStorage.removeFromStorage(this.cardsListId);
+      watchedStorage.removeFromStorageById(this.cardsListId);
       this.btnWatched.classList.remove('modal__btn-watched--active');
       this.btnWatched.textContent = 'Add to watched';
       this.btnWatched.blur();
@@ -105,11 +108,14 @@ class RenderModal {
   onBtnQueueClick() {
     this.btnQueue.classList.add('modal__btn-queue--active');
     if (this.movieAddedtoQueue !== true) {
-      queueStorage.addToStorage(this.cardsListId);
+      queueStorage.addToStorage({
+        ...this.currentMovie,
+        genre_ids: this.currentMovie.genres.map(x => x.id),
+      });
       this.btnQueue.textContent = 'Remove from queue';
       this.btnQueue.blur();
     } else {
-      queueStorage.removeFromStorage(this.cardsListId);
+      queueStorage.removeFromStorageById(this.cardsListId);
       this.btnQueue.classList.remove('modal__btn-queue--active');
       this.btnQueue.textContent = 'Add to queue';
       this.btnQueue.blur();


### PR DESCRIPTION
_JS:_

- refactor library-storage - now we add and remove movie object
- refactor render-one-card-modal - movie object has genre_ids, that needs to render one card
- refactor movie-service: now we get from storage movies