### PR TITLE
[fix] Body shifts to the right when modal is open

### DIFF
--- a/src/js/modules/components/render-one-card-modal.js
+++ b/src/js/modules/components/render-one-card-modal.js
@@ -32,8 +32,10 @@ class RenderModal {
           instance.close;
       },
       onClose: () => {
-        document.body.style.overflow = '';
-        document.body.style.marginRight = '';
+        setTimeout(() => {
+          document.body.style.overflow = '';
+          document.body.style.marginRight = '';
+        }, 300);
       },
     });
 
@@ -77,6 +79,10 @@ class RenderModal {
     );
 
     this.instance.show();
+    const scrollBarWidth = window.innerWidth - document.body.clientWidth;
+    document.body.style.overflow = 'hidden';
+    document.body.style.marginRight = `${scrollBarWidth}px`;
+
     document.addEventListener('keydown', evt => this.onEscModalClose(evt), {
       once: true,
     });


### PR DESCRIPTION
*JS*
- Fix scrolling and content shifting by 17px on all devices.
- Add a set timeout while the modal is closing to prevent the modal from jumping in render-one-card-moadl.js