### PR TITLE
[fix]-UP-PAGE-arrow-is-positioned-wrong-on-mobile-breakpoint

### DIFF
--- a/src/sass/components/_anchor-button.scss
+++ b/src/sass/components/_anchor-button.scss
@@ -1,7 +1,7 @@
 .anchor-btn {
   position: fixed;
   bottom: 15px;
-  right: 5px;
+  right: 15px;
   z-index: 99;
   width: 20px;
   height: 20px;
@@ -18,22 +18,17 @@
   transition: all 0.5s;
 
   @media screen and (min-width: 375px) {
-    bottom: 10px;
-    right: 7px;
     width: 27px;
     height: 27px;
     box-shadow: 0px 0px 4px 2px $accent-color inset;
   }
 
   @media screen and (min-width: 393px) {
-    right: 13px;
     width: 30px;
     height: 30px;
   }
 
   @media screen and (min-width: 425px) {
-    bottom: 13px;
-    right: 15px;
     width: 35px;
     height: 35px;
     border-radius: 20px;
@@ -41,13 +36,14 @@
   }
 
   @media screen and (min-width: 768px) {
-    right: 17px;
+  bottom: 20px;
+  right: 20px;
     width: 40px;
     height: 40px;
   }
 
   @media screen and (min-width: 1440px) {
-    bottom: 15px;
+    bottom: 30px;
     right: 30px;
     width: 45px;
     height: 45px;

--- a/src/sass/components/_anchor-button.scss
+++ b/src/sass/components/_anchor-button.scss
@@ -1,7 +1,7 @@
 .anchor-btn {
   position: fixed;
   bottom: 15px;
-  right: 0;
+  right: 5px;
   z-index: 99;
   width: 20px;
   height: 20px;


### PR DESCRIPTION
Add the padding from the edge of the page for the anchor button on the mobile breakpoint in the file "_anchor-button.scss"