### PR TITLE
[fix] stopPropagination on trailer modal

### DIFF
--- a/src/js/modules/components/render-movie-modal.js
+++ b/src/js/modules/components/render-movie-modal.js
@@ -153,14 +153,19 @@ class RenderModal {
     this.trailer = basicLightbox.create(trailerMarkup(this.currentMovie));
 
     this.trailer.show();
-    document.addEventListener('keydown', evt => this.onEscTrailerClose(evt), {
-      once: true,
-    });
+    document.body.addEventListener(
+      'keydown',
+      evt => this.onEscTrailerClose(evt),
+      {
+        once: true,
+      },
+    );
   }
 
   onEscTrailerClose(evt) {
     if (evt.code === 'Escape') {
       this.trailer.close();
+      evt.stopPropagation();
     }
   }
 }

--- a/src/sass/layout/_movie-card-modal.scss
+++ b/src/sass/layout/_movie-card-modal.scss
@@ -150,7 +150,7 @@
   text-decoration:none;
   color: inherit;
   margin-right: 7px;
-  
+  cursor: pointer;  
   &__img{
     width: 25px;
     display: inline-block;


### PR DESCRIPTION
*JS*
- Add keydown listener to body
- Add stopPropagination to close only one modal witn trailer in render-movie-modal.js

*Style*
- Add cursor to text "Watch trailer" in _movie-card-modal.scss